### PR TITLE
allowed php 8, added allowHtml to value field for html input (#10)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3||^8.0",
         "contao/core-bundle": "~4.4",
         "codefog/contao-haste": "^4.0"
     },

--- a/src/Resources/contao/dca/tl_constants.php
+++ b/src/Resources/contao/dca/tl_constants.php
@@ -129,7 +129,7 @@ $GLOBALS['TL_DCA']['tl_constants'] = [
             'search' => true,
             'filter' => true,
             'inputType' => 'textarea',
-            'eval' => ['mandatory' => true, 'tl_class' => 'long clr'],
+            'eval' => ['mandatory' => true, 'tl_class' => 'long clr', 'allowHtml' => true],
             'sql' => 'mediumtext NULL',
         ],
         'published' => [


### PR DESCRIPTION
I needed to include also allowHtml for the value field because else things like

```
<address>
    <a href="tel:+4912345678">Telefon</a>
</address>
```

for the legal notice ("impressum") wouldn't be possible.

I tested the whole bundle (create and replace in frontend) in php 8 without any issues.